### PR TITLE
Prepare pr fix4regression

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,15 @@ sql=# create extension postgis_raster;
 
 ## Usage
 
-  * To load a raster into a PostGIS database, the raster must first be loaded into a QGIS project. When the PostGIS Raster Import plugin is then started, the selection list `Raser layer` is filled with the loaded raster layers. Only file-based raster data can be loaded into the DB.
+  * To load a raster into a PostGIS database, the raster must first be loaded into a QGIS project. When the PostGIS Raster Import plugin is then started, the selection list `Raster layer` is filled with the loaded raster layers. Only file-based raster data can be loaded into the DB.
 
   * The next step is to select the database connection.
 
   * Select the schema in the selected database. In the selection list `Schema` all schemas of the selected database are displayed. A new schema can be created in the database by entering a new text in the selection list.
 
-  * In the input field `Table name` the name of the target table in the selected database must be entered.
-  * In addition, the option `create raster overviews` is available. If this option is activated, overview tables are created in addition to the raster table with the following levels: 4,8,16,32
+  * In the input field `Table name` the name of the target table in the selected database must be entered. As default, the layer name will be shown here, converted to lower case and with punctuation and spaces converted to underscore.
+
+  * In addition, the option `create raster overviews` is available. If this option is activated, overview tables are created in addition to the raster table with the following levels: 4, 8, 16, 32
 
 
 

--- a/pgraster_import_dialog_base.py
+++ b/pgraster_import_dialog_base.py
@@ -108,9 +108,10 @@ class PGRasterImportDialog(QDialog, FORM_CLASS):
         settings.endGroup()
         self.cmb_db_connections.setCurrentIndex(0)
         
-    def init_DB(self, selectedServer):
+    def init_DB(self, selectedServer: str) -> tuple[psycopg2.extensions.connection, str]:
+        """Ask for credentials and connect to DB. Return connection and password, or (None, None) if no connection possible."""
         if self.cmb_db_connections.currentIndex() == 0:
-            return None
+            return None, None
             
         settings = QSettings()
         mySettings = '/PostgreSQL/connections/' + selectedServer
@@ -133,7 +134,7 @@ class PGRasterImportDialog(QDialog, FORM_CLASS):
                 
             if not success:
                 QMessageBox.critical(None,  self.tr('Error'),  self.tr('Username or password incorrect!'))
-                return None
+                return None, None
                 
 #            QgsCredentials.instance().put(connection_info, user, password)
             DBUSER = user
@@ -145,13 +146,15 @@ class PGRasterImportDialog(QDialog, FORM_CLASS):
             conn = psycopg2.connect(connection_info)
         except:
             QMessageBox.critical(None,  self.tr('Error'),  str(sys.exc_info()[1]))
-            return None
-        
+            return None, None
+        return conn, DBPASSWD
+
+    def update_cmb_schema (self, schemas: list[str]):
         self.cmb_schema.clear()
-        self.cmb_schema.addItems(self.db_schemas(conn))
-        return conn,  DBPASSWD
-        
-    def db_schemas(self,  conn):
+        self.cmb_schema.addItems(schemas)
+
+    def db_schemas(self, conn):
+        """Retrieve valid schemas for import from DB connection `conn`"""
       
         sql = """
              SELECT n.nspname AS "Name"
@@ -163,12 +166,8 @@ class PGRasterImportDialog(QDialog, FORM_CLASS):
         cur.execute(sql)
         rows = cur.fetchall()
         
-        schema_list = []
-        for row in rows:
-            schema_list.append(row[0])
-            
-        return schema_list
-                    
+        schema_list = [row[0] for row in rows]
+        return schema_list                    
         
 #    @pyqtSlot()
 #    def on_button_box_accepted(self):
@@ -185,14 +184,15 @@ class PGRasterImportDialog(QDialog, FORM_CLASS):
     @pyqtSlot(str)
     def on_cmb_db_connections_currentIndexChanged(self, p0):
         """
-        Slot documentation goes here.
+        Update schema list when new DB is selected and enable buttons correspondingly.
         
-        @param p0 DESCRIPTION
+        @param p0 selected item
         @type str
         """
-        self.init_DB(p0)
-        self.enable_buttons()
-            
+        conn, _ = self.init_DB(p0)
+        if conn:
+            self.update_cmb_schema(self.db_schemas(conn))
+        self.enable_buttons()            
     
     @pyqtSlot()
     def on_btn_upload_clicked(self):
@@ -200,7 +200,7 @@ class PGRasterImportDialog(QDialog, FORM_CLASS):
         Slot documentation goes here.
         """
         conn,  password = self.init_DB(self.cmb_db_connections.currentText())
-        
+   
         if self.table_exists(conn,  self.cmb_schema.currentText(),  self.lne_table_name.text()):
             result = QMessageBox.question(
                 None,

--- a/pgraster_import_dialog_base.py
+++ b/pgraster_import_dialog_base.py
@@ -200,6 +200,8 @@ class PGRasterImportDialog(QDialog, FORM_CLASS):
         Slot documentation goes here.
         """
         conn,  password = self.init_DB(self.cmb_db_connections.currentText())
+        if not conn:  # invalid DB connection or no connection possible (wrong password etc.)
+            return
    
         if self.table_exists(conn,  self.cmb_schema.currentText(),  self.lne_table_name.text()):
             result = QMessageBox.question(
@@ -312,6 +314,12 @@ class PGRasterImportDialog(QDialog, FORM_CLASS):
 #{'dbname': 'test', 'user': 'postgres', 'port': '5432', 'sslmode': 'prefer'}
 
         conn,  passwd = self.init_DB(self.cmb_db_connections.currentText())
+        if not conn:
+            self.message(self.tr('PostGIS Raster Import'),
+                         self.tr('Could not load raster layer: database connection not available'),
+                         Qgis.Warning)
+            return
+
         db_connection_params = conn.get_dsn_parameters()
 
         uri_config = {


### PR DESCRIPTION
I’ve factored out updating the schema combobox from `init_DB()`, so that `init_DB()` can safely used repeatedly, esp. in `on_btn_upload_clicked()`.

The `return None` statements in `init_DB` are changed to `return None, None` in order to have a uniform return type (2-element tuple) for all cases. Thus, the return value can be safely unpacked (avoiding `cannot unpack non-iterable NoneType object` errors) and connection success checked.

I hope the schema selections now finally works.

I also added a little information about table name laundering to `README.md`.