### PR TITLE
Use layer CRS (CRS that has been set in QGIS) instead of data provider CRS

### DIFF
--- a/metadata.txt
+++ b/metadata.txt
@@ -30,9 +30,11 @@ repository=https://github.com/hdus/pg_raster_upload
 # Recommended items:
 
 hasProcessingProvider=no
+
 # Uncomment the following line and add your changelog:
 changelog=
   3.2.1
+  - Use layer CRS instead of file’s CRS (i.e. user can assign correct CRS in QGIS)
   - Do not import rasters without valid CRS
   - Fix “definition of service "None" not found” error when selecting DB
   - Create overviews for existing PostGIS rasters

--- a/pgraster_import_dialog_base.py
+++ b/pgraster_import_dialog_base.py
@@ -254,7 +254,7 @@ class PGRasterImportDialog(QDialog, FORM_CLASS):
         
         
         layer = self.cmb_map_layer.currentLayer()
-        if not layer.dataProvider().crs().isValid():
+        if not layer.crs().isValid():
             QMessageBox.warning(self, self.tr('Warning'),
                                 self.tr('Raster has no valid CRS'))
             return False

--- a/raster/raster_upload.py
+++ b/raster/raster_upload.py
@@ -91,7 +91,7 @@ class RasterUpload(QObject):
         # Burn all specified input raster files into single WKTRaster table
         gt = None
         layer_info = raster
-        self.opts['srid'] = layer_info['layer'].dataProvider().crs().postgisSrid()
+        self.opts['srid'] = layer_info['layer'].crs().postgisSrid()
         infile = layer_info['data_source']
         
         self.opts['schema_table'] = "\"%s\".\"%s\"" % (layer_info['schema_name'],  layer_info['table_name'])


### PR DESCRIPTION
If raster file does not provide a CRS (layer.dataProvider().crs() is invalid) or the file’s CRS is wrong, the user can set the CRS in QGIS, i.e. layer.crs() will be valid.